### PR TITLE
Compute next state for _all_ cells.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,68 +88,15 @@ impl World {
         return self.rule[state];
     }
 
-    // This is an obviously dumb way to do this
-    // TODO: Find a better way
-    fn neighbors(&self, cell: &Cell) -> CellSet {
-        let mut neighbors: CellSet = HashSet::with_capacity(8);
-        let (x, y) = (cell.0, cell.1);
-
-        let top = y.checked_sub(1) != None;
-        let bot = y.checked_add(1) <= Some(self.height);
-        let right = x.checked_add(1) <= Some(self.width);
-        let left = x.checked_sub(1) != None;
-
-        if right {
-            neighbors.insert((x + 1, y));
-        }
-        if right && bot {
-            neighbors.insert((x + 1, y + 1));
-        }
-        if right && top {
-            neighbors.insert((x + 1, y - 1));
-        }
-        if bot {
-            neighbors.insert((x, y + 1));
-        }
-        if top {
-            neighbors.insert((x, y - 1));
-        }
-        if left {
-            neighbors.insert((x - 1, y));
-        }
-        if left && bot {
-            neighbors.insert((x - 1, y + 1));
-        }
-        if left && top {
-            neighbors.insert((x - 1, y - 1));
-        }
-        neighbors
-    }
-
-    fn neighbor_count(&self, cell: &Cell) -> (CellSet, CellSet) {
-        let mut neighbors: (CellSet, CellSet) = (HashSet::with_capacity(8), HashSet::with_capacity(8));
-        for neighbor in self.neighbors(cell) {
-            if self.grid.contains(&neighbor) {
-                neighbors.0.insert(neighbor);
-            } else {
-                neighbors.1.insert(neighbor);
-            }
-        }
-        neighbors
-    }
-
     pub fn step(&mut self) {
         let mut new_state: CellSet = HashSet::with_capacity(self.width * self.height);
 
-        for cell in &self.grid {
-            let (living, dead) = self.neighbor_count(cell);
-            for itercell in living.union(&dead) {
-                if self.decide_next_state(itercell) {
-                    new_state.insert(*itercell);
+        for x in 0..self.width {
+            for y in 0..self.height {
+                let cell = (x, y);
+                if self.decide_next_state(&cell) {
+                    new_state.insert(cell);
                 }
-            }
-            if self.decide_next_state(cell) {
-                new_state.insert(*cell);
             }
         }
         self.grid = new_state;


### PR DESCRIPTION
Previously the state was computed only for live cells and their
neighbors. But this would fail for rules where a dead cell surrounded by
live cells comes alive (which is half of all randomly-chosen rules).

One could detect such rules by seeing if bit 0 is set in the rule (or,
equivalently, seeing if the rule number is odd), and then use a
different step function in that case, but I think it's probably simpler
to just use the same logic for all rules.